### PR TITLE
PR Fixes for initial implementation

### DIFF
--- a/ocr/__init__.py
+++ b/ocr/__init__.py
@@ -13,13 +13,17 @@ CONFIG = {
         {
             'name': 'clientUUID',
             'title': 'Client UUID',
-            'placeholder': 'Provided by OCR API',
+            'placeholder': 'One Click Retail client UUID',
+            'help': 'Your One Click Retail client UUID.'
+                    ' Provided by OCR API',
             'required': True
         },
         {
             'name': 'apiKey',
             'title': 'API Key',
-            'placeholder': 'Provided by OCR API',
+            'placeholder': 'One Click Retail API Key',
+            'help': 'Your One Click Retail API key.'
+                    ' Provided by OCR API',
             'required': True
         },
         {

--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -86,14 +86,15 @@ class OcrSource(panoply.DataSource):
     def _fetch_resource(self, resource):
         """
         Assemble the api call, execute it and parse the
-        csv response as a list of dicts
+        csv response as a list of dicts. Returns a dict generator
         """
 
         qs = self._build_qs()  # Build the query string
         url = self._build_url(qs)  # Build the full url
         fp = self._api_call(url)  # Fetch the data as a file pointer
-        reader = csv.DictReader(fp)  # Parse the csv file to a dict generator
-        return reader
+
+        # Parse the list of dicts in to a dict generator
+        return csv.DictReader(fp)
 
     def _build_qs(self):
         params = {

--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -2,7 +2,6 @@ import urllib
 import urllib2
 import csv
 from tempfile import SpooledTemporaryFile
-from datetime import datetime, date
 import panoply
 
 
@@ -12,7 +11,6 @@ IDPATTERN = '{week_asin}'
 BATCH_SIZE = 200
 FETCH_META = False
 DEFAULT_WEEKS_BACK = 1
-DATE_FORMAT = '%Y-%m-%d'
 MAX_SIZE = 100 * (1024 * 1024)  # 100mb
 
 
@@ -151,4 +149,3 @@ class OcrSource(panoply.DataSource):
             pass
 
         return batch
-

--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -50,7 +50,7 @@ class OcrSource(panoply.DataSource):
         self.processed = 0
         self.total = len(self.resources)
 
-    def read(self):
+    def read(self, batch_size=None):
         try:
             if not self.resource:
                 self.resource = self.resources.pop()
@@ -69,7 +69,7 @@ class OcrSource(panoply.DataSource):
         # Otherwise fetch data from the current resource.
         self.data = self.data or self._fetch_resource(self.resource)
 
-        batch = self._extract_batch(self.data)
+        batch = self._extract_batch(self.data, batch_size)
 
         # If no data was returned for this batch we might have reached
         # the end of the source - attempt to read more.
@@ -136,14 +136,17 @@ class OcrSource(panoply.DataSource):
 
         return self.tmp_file
 
-    def _extract_batch(self, data):
+    def _extract_batch(self, data, batch_size):
         """
         Iterates over BATCH_SIZE of data
         returning a list or results
         """
+
+        batch_size = BATCH_SIZE if batch_size is None else batch_size
+
         batch = []
         try:
-            for i in range(BATCH_SIZE):
+            for i in range(batch_size):
                 batch.append(data.next())
         except StopIteration:
             pass

--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -37,10 +37,10 @@ class OcrSource(panoply.DataSource):
         super(OcrSource, self).__init__(source, options)
 
         if not source.get('destination'):
-                source['destination'] = DESTINATION
+            source['destination'] = DESTINATION
 
         if not source.get('idpattern'):
-                source['idpattern'] = IDPATTERN
+            source['idpattern'] = IDPATTERN
 
         if not source.get('resources'):
             raise Exception('No resources selected')

--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -13,7 +13,7 @@ BATCH_SIZE = 200
 FETCH_META = False
 DEFAULT_WEEKS_BACK = 1
 DATE_FORMAT = '%Y-%m-%d'
-MAX_SIZE = 104857600  # 100mb
+MAX_SIZE = 100 * (1024 * 1024)  # 100mb
 
 
 class OcrSource(panoply.DataSource):

--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -75,20 +75,6 @@ class OcrSource(panoply.DataSource):
 
         return batch
 
-    def _extract_batch(self, data):
-        """
-        Iterates over BATCH_SIZE of data
-        returning a list or results
-        """
-        batch = []
-        try:
-            for i in range(BATCH_SIZE):
-                batch.append(data.next())
-        except StopIteration:
-            pass
-
-        return batch
-
     def _fetch_resource(self, resource):
         """
         Assemble the api call, execute it and parse the
@@ -145,3 +131,18 @@ class OcrSource(panoply.DataSource):
         self.tmp_file.seek(0)
 
         return self.tmp_file
+
+    def _extract_batch(self, data):
+        """
+        Iterates over BATCH_SIZE of data
+        returning a list or results
+        """
+        batch = []
+        try:
+            for i in range(BATCH_SIZE):
+                batch.append(data.next())
+        except StopIteration:
+            pass
+
+        return batch
+

--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -135,7 +135,7 @@ class OcrSource(panoply.DataSource):
         returning a list or results
         """
 
-        batch_size = BATCH_SIZE if batch_size is None else batch_size
+        batch_size = batch_size or BATCH_SIZE
 
         batch = []
         try:

--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -22,15 +22,6 @@ class OcrSource(panoply.DataSource):
     GET /v3/clients/{client_uuid}/reports/csv
     """
 
-    resources = None
-    resource = None
-    tmp_file = None
-    data = []
-
-    api_key = None
-    weeks = None
-    clientUUID = None
-
     def __init__(self, source, options):
         super(OcrSource, self).__init__(source, options)
 
@@ -43,6 +34,8 @@ class OcrSource(panoply.DataSource):
         if not source.get('resources'):
             raise Exception('No resources selected')
 
+        self.resource = None
+        self.data = None
         self.resources = source.get('resources')
         self.api_key = source.get('apiKey')
         self.weeks = source.get('weeks', DEFAULT_WEEKS_BACK)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-panoply-python-sdk==1.3.2
-mock==2.0.0

--- a/test.py
+++ b/test.py
@@ -44,18 +44,18 @@ class TestOneClickRetail(unittest.TestCase):
 
     # Return none when no more resources are left
     @patch('ocr.OcrSource._fetch_resource')
-    @patch('ocr.ocr.BATCH_SIZE', 3)
+    @patch('ocr.BATCH_SIZE', 3)
     def test_returns_none_when_done(self, fetch_resources):
         data = ['first_data', 'second_data', 'third_data']
         fetch_resources.return_value = iter(data)
-        # First call should return 3 items
+        # first call should return 3 items
         first_call = self.stream.read()
-        # Second call should not return items
+        # second call should not return items
         second_call = self.stream.read()
-        # First batch should contain all data
-        self.assertEqual(first_call, data)
-        # Second batch should be empty
-        self.assertIsNone(second_call)
+        # first batch should contain all data
+        self.assertequal(first_call, data)
+        # second batch should be empty
+        self.assertisnone(second_call)
 
     # Raises exception if response is not a csv
     @patch('ocr.urllib2.urlopen')
@@ -69,6 +69,30 @@ class TestOneClickRetail(unittest.TestCase):
         l = ['v1', 'v2']
         self.stream._extract_batch(iter(l))
         self.assertIsNone(self.stream.resource)
+
+    # Increases process count when processing resources
+    @patch('ocr.OcrSource._fetch_resource')
+    @patch('ocr.BATCH_SIZE', 3)
+    def test_returns_none_when_done(self, fetch_resources):
+        self.source['resources'].append(
+            {'name': 'another resource', 'value': 'another value'}
+        )
+        self.stream = OcrSource(self.source, OPTIONS)
+        data = ['first_data', 'second_data', 'third_data']
+        fetch_resources.return_value = iter(data)
+
+        # Nothing processed at the begining
+        self.assertEqual(self.stream.processed, 0)
+
+        # First read should return all data in one batch
+        self.stream.read()
+        # Processed one resource
+        self.assertEqual(self.stream.processed, 1)
+
+        # Second read should move to next resource
+        self.stream.read()
+        # Processed two resource
+        self.assertEqual(self.stream.processed, 2)
 
 
 # Run the test suite

--- a/test.py
+++ b/test.py
@@ -52,7 +52,9 @@ class TestOneClickRetail(unittest.TestCase):
         first_call = self.stream.read()
         # Second call should not return items
         second_call = self.stream.read()
-        self.assertIsNotNone(first_call)
+        # First batch should contain all data
+        self.assertEqual(first_call, data)
+        # Second batch should be empty
         self.assertIsNone(second_call)
 
     # Raises exception if response is not a csv

--- a/test.py
+++ b/test.py
@@ -53,9 +53,9 @@ class TestOneClickRetail(unittest.TestCase):
         # second call should not return items
         second_call = self.stream.read()
         # first batch should contain all data
-        self.assertequal(first_call, data)
+        self.assertEqual(first_call, data)
         # second batch should be empty
-        self.assertisnone(second_call)
+        self.assertIsNone(second_call)
 
     # Raises exception if response is not a csv
     @patch('ocr.urllib2.urlopen')
@@ -73,7 +73,7 @@ class TestOneClickRetail(unittest.TestCase):
     # Increases process count when processing resources
     @patch('ocr.OcrSource._fetch_resource')
     @patch('ocr.BATCH_SIZE', 3)
-    def test_returns_none_when_done(self, fetch_resources):
+    def test_increases_processed_count(self, fetch_resources):
         self.source['resources'].append(
             {'name': 'another resource', 'value': 'another value'}
         )

--- a/test.py
+++ b/test.py
@@ -67,7 +67,7 @@ class TestOneClickRetail(unittest.TestCase):
     # Sets resource to None once no more batches are left
     def test_extract_batch(self):
         l = ['v1', 'v2']
-        self.stream._extract_batch(iter(l))
+        self.stream._extract_batch(iter(l), None)
         self.assertIsNone(self.stream.resource)
 
     # Increases process count when processing resources


### PR DESCRIPTION
@aviaoh - 

- requirements.txt is redundant. - 4903bae
- assert also first_call content (rather than just not None) - bdb228c
- Help text added. Also screenshots added to PR - 0d3765f
  - http://i.imgur.com/87nToXs.png
  - http://i.imgur.com/Ib7CZ1w.png
- More extendable max size constant definition - 77db68a
- Fixed over indentation - 378a295
- "line 54-61 - isn't it the same as checking if self.resources is not empty?" - 
  It is essentially the same but since read might be called multiple times on the same resouce, the actual contidion is `self.resource`. Only when there is no "current" resource do we try to `pop()` a new resoure - and only when there are none do we want to end the stream and return `None`.
- Functions located at the same order as they called - 89fa7be
- Report progress with number of resources left - 2914559
- Directly return csv.dictReader and comment on it being a generator - 6507f67
- "in _api_call - should we also check the response status?" - 
  The check I am currently doing is to see if the response is a CSV file. Any connection issues will raise its own IOError and if the response is not a CSV file an appropriate exception is raised. I'm not too concerned with any other error. 

@kensaggy - 

- `read()` signature should accept batch size - ff1fb8d
- Removed confusing use of class variables - f1449bd

