### PR TITLE
Handle unencodable strings by replacing the problematic charaters

### DIFF
--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -123,10 +123,9 @@ class OcrSource(panoply.DataSource):
         if 'csv' not in content_type:
             raise Exception('ERROR - Non CSV response.')
 
-        raw_data = response.read()
         # Decode the returned data and replace any characters that generate
         # encoding errors with the default unicode replacement character.
-        data = raw_data.decode('utf-8', 'replace')
+        data = response.read().decode('utf-8', 'replace')
 
         self.tmp_file = SpooledTemporaryFile(max_size=MAX_SIZE)
         # Force writing the data encoded as utf-8. If we don't do this,

--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -114,15 +114,27 @@ class OcrSource(panoply.DataSource):
         large of a file the api will return.
         We are expecting a csv file.
         """
+        self.log('Request URL', url)
         response = urllib2.urlopen(url)
+        self.log('Got response', response)
 
         # the response MUST be a csv file
         content_type = response.info().get('content-type')
         if 'csv' not in content_type:
             raise Exception('ERROR - Non CSV response.')
 
+        raw_data = response.read()
+        # Decode the returned data and replace any characters that generate
+        # encoding errors with the default unicode replacement character.
+        data = raw_data.decode('utf-8', 'replace')
+
         self.tmp_file = SpooledTemporaryFile(max_size=MAX_SIZE)
-        self.tmp_file.write(response.read())
+        # Force writing the data encoded as utf-8. If we don't do this,
+        # python will attempt to write the data as 'ascii' which does not
+        # support special characters
+
+        self.tmp_file.write(data.encode('utf-8'))
+
         # 'rewind' the file pointer in order to
         # read it back durring `_extract_batch()`
         self.tmp_file.seek(0)

--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -60,7 +60,7 @@ class OcrSource(panoply.DataSource):
 
         # If data remains from the last resource, use it.
         # Otherwise fetch data from the current resource.
-        self.data = self.data or self._fetch_resource(self.resource)
+        self.data = self.data or self._fetch_resource()
 
         batch = self._extract_batch(self.data, batch_size)
 
@@ -74,7 +74,7 @@ class OcrSource(panoply.DataSource):
 
         return batch
 
-    def _fetch_resource(self, resource):
+    def _fetch_resource(self):
         """
         Assemble the api call, execute it and parse the
         csv response as a list of dicts. Returns a dict generator

--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -116,7 +116,6 @@ class OcrSource(panoply.DataSource):
         """
         self.log('Request URL', url)
         response = urllib2.urlopen(url)
-        self.log('Got response', response)
 
         # the response MUST be a csv file
         content_type = response.info().get('content-type')

--- a/test.py
+++ b/test.py
@@ -68,7 +68,7 @@ class TestOneClickRetail(unittest.TestCase):
     @patch('ocr.urllib2.urlopen')
     def test_hanldes_unencodable_strings(self, mock_urlopen):
         res_mock = Mock()
-        res_mock.info.side_effect = self.foo
+        res_mock.info.side_effect = lambda: {'content-type': 'csv'}
         # The characters here represent a copywrite symbol
         res_mock.read.side_effect = lambda: "{'problem_text': 'OHNO!\xc2\xae'}"
         mock_urlopen.return_value = res_mock
@@ -80,9 +80,6 @@ class TestOneClickRetail(unittest.TestCase):
             exception_raised = e
 
         self.assertFalse(exception_raised, exception_raised)
-
-    def foo(self):
-        return {'content-type': 'csv'}
 
     # Sets resource to None once no more batches are left
     def test_extract_batch(self):


### PR DESCRIPTION
Ensure that all data is decoded and written in `utf-8` encoding. This change was needed after we detected some malformed unicode control characters.

I've also added a test to prevent regressions for this change. 